### PR TITLE
Fix CI ruff command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Black
         run: poetry run black --check .
       - name: Run Ruff
-        run: poetry run ruff .
+        run: poetry run ruff check .
       - name: Run Mypy
         run: poetry run mypy src tests
 

--- a/src/rule_manager/main.py
+++ b/src/rule_manager/main.py
@@ -133,26 +133,25 @@ def load_settings_from_args(args: argparse.Namespace) -> ServerSettings:
     return ServerSettings(**settings_kwargs)
 
 
-
 def main():
     """Main entry point"""
     parser = create_parser()
     args = parser.parse_args()
-    
+
     try:
         # Load settings
         settings = load_settings_from_args(args)
-        
+
         # Create server
         server = RuleManagerServer(settings)
-        
+
         print(f"Starting Rule Manager MCP Server...")
         print(f"Transport: {settings.transport}")
         if settings.transport != "stdio":
             print(f"Address: {settings.host}:{settings.port}")
         print(f"Rules Directory: {settings.rules_dir}")
         print(f"Storage Backend: {settings.storage_backend}")
-        
+
         # Let FastMCP handle the event loop
         if settings.transport == "stdio":
             server.mcp.run(transport="stdio")
@@ -161,17 +160,13 @@ def main():
                 transport="streamable-http",
                 host=settings.host,
                 port=settings.port,
-                async_mode=settings.async_mode
+                async_mode=settings.async_mode,
             )
         elif settings.transport == "sse":
-            server.mcp.run(
-                transport="sse",
-                host=settings.host,
-                port=settings.port
-            )
+            server.mcp.run(transport="sse", host=settings.host, port=settings.port)
         else:
             raise ValueError(f"Unsupported transport: {settings.transport}")
-            
+
     except KeyboardInterrupt:
         print("\nShutting down gracefully...")
     except Exception as e:

--- a/src/rule_manager/server.py
+++ b/src/rule_manager/server.py
@@ -381,4 +381,3 @@ class RuleManagerServer:
                     "error": str(e),
                     "timestamp": datetime.utcnow().isoformat(),
                 }
-

--- a/src/rule_manager/storage/yaml_store.py
+++ b/src/rule_manager/storage/yaml_store.py
@@ -85,7 +85,7 @@ class YAMLRuleStore(RuleStore):
                 rule.created_at = now
             rule.updated_at = now
 
-        ruleset_dict = ruleset.model_dump(mode='json')
+        ruleset_dict = ruleset.model_dump(mode="json")
         await self._save_yaml_file(file_path, ruleset_dict)
 
     async def get_rule(


### PR DESCRIPTION
## Summary
- fix ruff invocation in CI workflow

## Testing
- `black --check .` *(fails: would reformat)*
- `ruff check .` *(fails: found 177 errors)*
- `mypy src tests` *(fails: found 95 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_685d2b69e954832c9a814ea77802d537