### PR TITLE
Fix Ruff lint errors

### DIFF
--- a/scripts/debug_mcp.py
+++ b/scripts/debug_mcp.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""
-Debug MCP Server
+"""Debug MCP Server
 
 Debug the FastMCP tool registration process.
 """
+
+# ruff: noqa: E402
 
 import asyncio
 import sys
@@ -14,6 +15,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
 from fastmcp import FastMCP
+
 from rule_manager.models.settings import ServerSettings
 from rule_manager.server import RuleManagerServer
 
@@ -111,9 +113,9 @@ async def debug_fastmcp_registration():
                         break
 
                 if health_tool:
-                    print(f"   🔧 Testing health_check tool...")
+                    print("   🔧 Testing health_check tool...")
                     # We can't call it directly here, but we know it exists
-                    print(f"   ✅ health_check tool found and ready")
+                    print("   ✅ health_check tool found and ready")
 
         except Exception as e:
             print(f"   ❌ Tool call test failed: {e}")

--- a/scripts/minimal_mcp_test.py
+++ b/scripts/minimal_mcp_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""
-Minimal MCP Server Test
+"""Minimal MCP Server Test
 
 Test basic FastMCP functionality to understand the API.
 """
+
+# ruff: noqa: E402
 
 import asyncio
 import sys
@@ -43,7 +44,7 @@ async def test_minimal_mcp():
         tools = list(mcp._tools.keys())
         print(f"   📋 Registered tools: {tools}")
     elif hasattr(mcp, "tools"):
-        print(f"   📋 Tools attribute found")
+        print("   📋 Tools attribute found")
     else:
         print("   ⚠️ No tools attribute found")
 
@@ -100,7 +101,7 @@ async def main():
     print("🔬 FastMCP API Exploration")
     print("=" * 30)
 
-    mcp = await test_minimal_mcp()
+    _ = await test_minimal_mcp()
     await test_fastmcp_run()
 
     print("\n" + "=" * 30)

--- a/scripts/simple_test.py
+++ b/scripts/simple_test.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""
-Simple MCP Server Test
+"""Simple MCP Server Test
 
 Test the MCP server by directly calling the tools without going through
 the MCP protocol.
 """
+
+# ruff: noqa: E402
 
 import asyncio
 import sys
@@ -14,9 +15,9 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
-from rule_manager.models.base import RuleContext, RuleScope, RuleAction
-from rule_manager.models.settings import ServerSettings
 from rule_manager.core.engine import RuleEngine
+from rule_manager.models.base import RuleAction, RuleContext, RuleScope
+from rule_manager.models.settings import ServerSettings
 from rule_manager.storage.yaml_store import YAMLRuleStore
 
 
@@ -83,7 +84,7 @@ async def test_rule_engine_directly():
 
         result = await engine.evaluate_rules(test_context)
 
-        print(f"   ✅ Evaluation successful:")
+        print("   ✅ Evaluation successful:")
         print(f"   📊 Final action: {result.final_action}")
         print(
             f"   📊 Matched rules: {result.matched_rules_count}/{result.applicable_rules_count}"

--- a/scripts/test_mcp.py
+++ b/scripts/test_mcp.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""
-MCP Server Testing Script
+"""MCP Server Testing Script
 
 This script tests the MCP server functionality by connecting to it
 and executing various MCP tools.
 """
 
+# ruff: noqa: E402
+
 import asyncio
-import json
 import sys
 from pathlib import Path
 
@@ -15,7 +15,7 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
-from rule_manager.models.base import RuleContext, RuleScope, RuleAction
+from rule_manager.models.base import RuleAction, RuleContext, RuleScope
 from rule_manager.models.settings import ServerSettings
 from rule_manager.server import RuleManagerServer
 
@@ -85,7 +85,7 @@ async def test_mcp_tools():
             final_action = eval_result.get("final_action")
             matched_count = eval_result.get("matched_rules_count", 0)
             total_time = eval_result.get("total_execution_time_ms", 0)
-            print(f"   ✅ Evaluation successful:")
+            print("   ✅ Evaluation successful:")
             print(f"   📊 Final action: {final_action}")
             print(f"   📊 Matched rules: {matched_count}")
             print(f"   ⏱️ Execution time: {total_time:.2f}ms")
@@ -170,7 +170,7 @@ async def test_mcp_tools():
                 f"   ⚠️ Rule deletion failed (may not exist): {delete_result['error']}"
             )
         else:
-            print(f"   ✅ Rule deleted successfully")
+            print("   ✅ Rule deleted successfully")
 
     except Exception as e:
         print(f"   ❌ Rule deletion failed: {e}")

--- a/scripts/test_stdio.py
+++ b/scripts/test_stdio.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""
-Test MCP Server in STDIO mode
+"""Test MCP Server in STDIO mode
 
 This script tests the MCP server by starting it and sending MCP messages
 through stdin/stdout.
 """
 
+# ruff: noqa: E402
+
 import asyncio
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -73,7 +73,7 @@ async def test_mcp_stdio():
             else:
                 print("   ❌ No response from server")
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             print("   ❌ Initialization timeout")
         except json.JSONDecodeError as e:
             print(f"   ❌ Invalid JSON response: {e}")
@@ -108,7 +108,7 @@ async def test_mcp_stdio():
             else:
                 print("   ❌ No response to tools/list")
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             print("   ❌ Tools/list timeout")
         except json.JSONDecodeError as e:
             print(f"   ❌ Invalid JSON response: {e}")
@@ -148,7 +148,7 @@ async def test_mcp_stdio():
             else:
                 print("   ❌ No response to health_check")
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             print("   ❌ Health check timeout")
         except (json.JSONDecodeError, KeyError) as e:
             print(f"   ❌ Error parsing health response: {e}")
@@ -160,7 +160,7 @@ async def test_mcp_stdio():
         try:
             await asyncio.wait_for(server_process.wait(), timeout=3.0)
             print("   ✅ Server terminated gracefully")
-        except asyncio.TimeoutError:
+        except TimeoutError:
             server_process.kill()
             await server_process.wait()
             print("   ⚠️ Server force-killed")

--- a/scripts/test_working_mcp.py
+++ b/scripts/test_working_mcp.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""
-Test Working MCP Server
+"""Test Working MCP Server
 
 Test the rule manager MCP server using the correct FastMCP API.
 """
+
+# ruff: noqa: E402
 
 import asyncio
 import sys
@@ -13,7 +14,7 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
-from rule_manager.models.base import RuleContext, RuleScope, RuleAction
+from rule_manager.models.base import RuleContext
 from rule_manager.models.settings import ServerSettings
 from rule_manager.server import RuleManagerServer
 
@@ -91,7 +92,7 @@ async def test_server_tools():
             request = EvaluateRulesRequest(context=test_context)
             result = await eval_tool.function(request)
 
-            print(f"   ✅ Evaluation result:")
+            print("   ✅ Evaluation result:")
             print(f"      📊 Final action: {result.get('final_action')}")
             print(f"      📊 Matched rules: {result.get('matched_rules_count')}")
             print(f"      ⏱️ Time: {result.get('total_execution_time_ms'):.2f}ms")
@@ -154,7 +155,7 @@ async def test_mcp_server_startup():
 
     server = RuleManagerServer(settings)
 
-    print(f"   ✅ Server initialized")
+    print("   ✅ Server initialized")
     print(f"   📋 Transport: {settings.transport}")
     print(f"   📋 Rules dir: {settings.rules_dir}")
     print(f"   📋 Storage: {settings.storage_backend}")

--- a/src/rule_manager/core/dsl.py
+++ b/src/rule_manager/core/dsl.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
+
 from ..models.base import RuleContext
 from ..models.errors import RuleDSLSyntaxError
 
@@ -47,7 +48,9 @@ class DSLEvaluator:
         try:
             return self._evaluate_expression(expression.strip(), context)
         except Exception as e:
-            raise RuleDSLSyntaxError(f"Failed to evaluate expression: {e}", expression)
+            raise RuleDSLSyntaxError(
+                f"Failed to evaluate expression: {e}", expression
+            ) from e
 
     def _evaluate_expression(self, expr: str, context: RuleContext) -> bool:
         # Handle logical operators
@@ -101,7 +104,7 @@ class DSLEvaluator:
 
         parts = expr.split(operator, 1)
         if len(parts) != 2:
-            raise RuleDSLSyntaxError(f"Invalid comparison expression", expr)
+            raise RuleDSLSyntaxError("Invalid comparison expression", expr)
 
         left = self._parse_value(parts[0].strip(), context)
         right = self._parse_value(parts[1].strip(), context)
@@ -109,7 +112,7 @@ class DSLEvaluator:
         try:
             return self.operators[operator](left, right)
         except Exception as e:
-            raise RuleDSLSyntaxError(f"Error in comparison: {e}", expr)
+            raise RuleDSLSyntaxError(f"Error in comparison: {e}", expr) from e
 
     def _parse_value(self, value: str, context: RuleContext) -> Any:
         value = value.strip()
@@ -174,7 +177,7 @@ class DSLEvaluator:
 
         return None
 
-    def validate_expression(self, expression: str) -> List[str]:
+    def validate_expression(self, expression: str) -> list[str]:
         """
         Validate an expression and return a list of issues found.
         Returns empty list if expression is valid.

--- a/src/rule_manager/main.py
+++ b/src/rule_manager/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import asyncio
 import sys
 from pathlib import Path
 
@@ -123,7 +122,6 @@ def load_settings_from_args(args: argparse.Namespace) -> ServerSettings:
     # Handle environment file
     if args.env_file:
         # Override the default env_file in model_config
-        import os
 
         if Path(args.env_file).exists():
             settings_kwargs["_env_file"] = args.env_file
@@ -138,21 +136,21 @@ def main():
     """Main entry point"""
     parser = create_parser()
     args = parser.parse_args()
-    
+
     try:
         # Load settings
         settings = load_settings_from_args(args)
-        
+
         # Create server
         server = RuleManagerServer(settings)
-        
-        print(f"Starting Rule Manager MCP Server...")
+
+        print("Starting Rule Manager MCP Server...")
         print(f"Transport: {settings.transport}")
         if settings.transport != "stdio":
             print(f"Address: {settings.host}:{settings.port}")
         print(f"Rules Directory: {settings.rules_dir}")
         print(f"Storage Backend: {settings.storage_backend}")
-        
+
         # Let FastMCP handle the event loop
         if settings.transport == "stdio":
             server.mcp.run(transport="stdio")
@@ -171,7 +169,7 @@ def main():
             )
         else:
             raise ValueError(f"Unsupported transport: {settings.transport}")
-            
+
     except KeyboardInterrupt:
         print("\nShutting down gracefully...")
     except Exception as e:

--- a/src/rule_manager/models/base.py
+++ b/src/rule_manager/models/base.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -29,15 +30,15 @@ class Rule(BaseModel):
     name: str
     scope: RuleScope
     priority: int = Field(ge=0, le=100, default=50)
-    conditions: Dict[str, Any] = Field(default_factory=dict)
+    conditions: dict[str, Any] = Field(default_factory=dict)
     action: RuleAction
-    parameters: Dict[str, Any] = Field(default_factory=dict)
-    parent_rule: Optional[str] = None
-    inherits_from: Optional[List[str]] = None
-    description: Optional[str] = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    parent_rule: str | None = None
+    inherits_from: list[str] | None = None
+    description: str | None = None
     enabled: bool = True
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
+    created_at: str | None = None
+    updated_at: str | None = None
 
 
 class RuleSet(BaseModel):
@@ -46,20 +47,20 @@ class RuleSet(BaseModel):
     ruleset_version: str = "1.1"
     engine_min_version: str = ">=2.8.0"
     scope: RuleScope
-    rules: List[Rule] = Field(default_factory=list)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    rules: list[Rule] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class RuleContext(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    user_id: Optional[str] = None
-    project_id: Optional[str] = None
-    session_id: Optional[str] = None
-    model_name: Optional[str] = None
-    prompt_length: Optional[int] = None
-    timestamp: Optional[str] = None
-    custom_attributes: Dict[str, Any] = Field(default_factory=dict)
+    user_id: str | None = None
+    project_id: str | None = None
+    session_id: str | None = None
+    model_name: str | None = None
+    prompt_length: int | None = None
+    timestamp: str | None = None
+    custom_attributes: dict[str, Any] = Field(default_factory=dict)
 
 
 class RuleEvaluationResult(BaseModel):
@@ -68,17 +69,17 @@ class RuleEvaluationResult(BaseModel):
     rule_name: str
     action: RuleAction
     matched: bool
-    parameters: Dict[str, Any] = Field(default_factory=dict)
-    message: Optional[str] = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    message: str | None = None
     priority: int
-    execution_time_ms: Optional[float] = None
+    execution_time_ms: float | None = None
 
 
 class RuleEvaluationSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     context: RuleContext
-    results: List[RuleEvaluationResult]
+    results: list[RuleEvaluationResult]
     final_action: RuleAction
     total_execution_time_ms: float
     evaluated_at: str

--- a/src/rule_manager/models/settings.py
+++ b/src/rule_manager/models/settings.py
@@ -1,6 +1,6 @@
 import os
-from typing import Literal, Optional
-from pydantic import Field
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .base import PriorityTieBreaking
@@ -33,7 +33,7 @@ class ServerSettings(BaseSettings):
 
     # Security settings
     enable_auth: bool = False
-    jwt_secret_key: Optional[str] = None
+    jwt_secret_key: str | None = None
     jwt_algorithm: str = "HS256"
     jwt_expiration_hours: int = 24
 
@@ -70,7 +70,7 @@ class CLISettings(BaseSettings):
         extra="ignore",
     )
 
-    config_file: Optional[str] = None
-    env_file: Optional[str] = None
+    config_file: str | None = None
+    env_file: str | None = None
     verbose: bool = False
     debug: bool = False

--- a/src/rule_manager/server.py
+++ b/src/rule_manager/server.py
@@ -1,23 +1,18 @@
-import asyncio
-import json
-from typing import Any, Dict, List, Optional
 from datetime import datetime
+from typing import Any
 
 from fastmcp import FastMCP
 from pydantic import BaseModel
 
+from .core.engine import RuleEngine
 from .models.base import (
     Rule,
-    RuleSet,
-    RuleScope,
     RuleAction,
     RuleContext,
-    RuleEvaluationSummary,
-    PriorityTieBreaking,
+    RuleScope,
 )
-from .models.settings import ServerSettings
 from .models.errors import RuleManagerError
-from .core.engine import RuleEngine
+from .models.settings import ServerSettings
 from .storage.yaml_store import YAMLRuleStore
 
 
@@ -25,26 +20,26 @@ class CreateRuleRequest(BaseModel):
     name: str
     scope: RuleScope
     priority: int = 50
-    conditions: Dict[str, Any] = {}
+    conditions: dict[str, Any] = {}
     action: RuleAction
-    parameters: Dict[str, Any] = {}
-    parent_rule: Optional[str] = None
-    inherits_from: Optional[List[str]] = None
-    description: Optional[str] = None
+    parameters: dict[str, Any] = {}
+    parent_rule: str | None = None
+    inherits_from: list[str] | None = None
+    description: str | None = None
     enabled: bool = True
 
 
 class UpdateRuleRequest(BaseModel):
     name: str
     scope: RuleScope
-    priority: Optional[int] = None
-    conditions: Optional[Dict[str, Any]] = None
-    action: Optional[RuleAction] = None
-    parameters: Optional[Dict[str, Any]] = None
-    parent_rule: Optional[str] = None
-    inherits_from: Optional[List[str]] = None
-    description: Optional[str] = None
-    enabled: Optional[bool] = None
+    priority: int | None = None
+    conditions: dict[str, Any] | None = None
+    action: RuleAction | None = None
+    parameters: dict[str, Any] | None = None
+    parent_rule: str | None = None
+    inherits_from: list[str] | None = None
+    description: str | None = None
+    enabled: bool | None = None
 
 
 class EvaluateRulesRequest(BaseModel):
@@ -78,7 +73,7 @@ class RuleManagerServer:
         """Register all MCP tools"""
 
         @self.mcp.tool()
-        async def evaluate_rules(request: EvaluateRulesRequest) -> Dict[str, Any]:
+        async def evaluate_rules(request: EvaluateRulesRequest) -> dict[str, Any]:
             """
             Evaluate rules against a given context and return the results.
 
@@ -109,7 +104,7 @@ class RuleManagerServer:
                 }
 
         @self.mcp.tool()
-        async def create_rule(request: CreateRuleRequest) -> Dict[str, Any]:
+        async def create_rule(request: CreateRuleRequest) -> dict[str, Any]:
             """
             Create a new rule.
 
@@ -154,7 +149,7 @@ class RuleManagerServer:
                 }
 
         @self.mcp.tool()
-        async def update_rule(request: UpdateRuleRequest) -> Dict[str, Any]:
+        async def update_rule(request: UpdateRuleRequest) -> dict[str, Any]:
             """
             Update an existing rule.
 
@@ -209,7 +204,7 @@ class RuleManagerServer:
                 }
 
         @self.mcp.tool()
-        async def delete_rule(rule_name: str, scope: str) -> Dict[str, Any]:
+        async def delete_rule(rule_name: str, scope: str) -> dict[str, Any]:
             """
             Delete a rule.
 
@@ -252,7 +247,7 @@ class RuleManagerServer:
                 }
 
         @self.mcp.tool()
-        async def list_rules(scope: Optional[str] = None) -> Dict[str, Any]:
+        async def list_rules(scope: str | None = None) -> dict[str, Any]:
             """
             List all rules, optionally filtered by scope.
 
@@ -290,8 +285,8 @@ class RuleManagerServer:
 
         @self.mcp.tool()
         async def get_rule(
-            rule_name: str, scope: Optional[str] = None
-        ) -> Dict[str, Any]:
+            rule_name: str, scope: str | None = None
+        ) -> dict[str, Any]:
             """
             Get a specific rule by name and optional scope.
 
@@ -334,7 +329,7 @@ class RuleManagerServer:
                 }
 
         @self.mcp.tool()
-        async def validate_rule_dsl(expression: str) -> Dict[str, Any]:
+        async def validate_rule_dsl(expression: str) -> dict[str, Any]:
             """
             Validate a rule DSL expression.
 
@@ -358,7 +353,7 @@ class RuleManagerServer:
                 }
 
         @self.mcp.tool()
-        async def health_check() -> Dict[str, Any]:
+        async def health_check() -> dict[str, Any]:
             """
             Perform a health check of the rule manager service.
 

--- a/src/rule_manager/storage/base.py
+++ b/src/rule_manager/storage/base.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
 
-from ..models.base import Rule, RuleSet, RuleScope
+from ..models.base import Rule, RuleScope, RuleSet
 
 
 class RuleStore(ABC):
@@ -15,8 +14,8 @@ class RuleStore(ABC):
 
     @abstractmethod
     async def get_rule(
-        self, rule_name: str, scope: Optional[RuleScope] = None
-    ) -> Optional[Rule]:
+        self, rule_name: str, scope: RuleScope | None = None
+    ) -> Rule | None:
         pass
 
     @abstractmethod
@@ -32,7 +31,7 @@ class RuleStore(ABC):
         pass
 
     @abstractmethod
-    async def list_rules(self, scope: Optional[RuleScope] = None) -> List[Rule]:
+    async def list_rules(self, scope: RuleScope | None = None) -> list[Rule]:
         pass
 
     @abstractmethod

--- a/src/rule_manager/utils/logging.py
+++ b/src/rule_manager/utils/logging.py
@@ -1,6 +1,7 @@
 import logging
 import sys
-from typing import Any, Dict, Optional
+from typing import Any
+
 import structlog
 from structlog.stdlib import LoggerFactory
 
@@ -66,7 +67,7 @@ class AuditLogger:
     Logs to both structured logs and append-only database.
     """
 
-    def __init__(self, audit_log_path: Optional[str] = None):
+    def __init__(self, audit_log_path: str | None = None):
         self.logger = get_logger("audit")
         self.audit_log_path = audit_log_path
 
@@ -75,9 +76,9 @@ class AuditLogger:
         operation: str,
         rule_name: str,
         scope: str,
-        user_id: Optional[str] = None,
+        user_id: str | None = None,
         success: bool = True,
-        error_message: Optional[str] = None,
+        error_message: str | None = None,
         **extra_context: Any,
     ) -> None:
         """
@@ -114,9 +115,9 @@ class AuditLogger:
         user_id: str,
         success: bool,
         method: str = "jwt",
-        ip_address: Optional[str] = None,
-        user_agent: Optional[str] = None,
-        error_message: Optional[str] = None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+        error_message: str | None = None,
     ) -> None:
         """
         Log an authentication attempt.
@@ -151,9 +152,9 @@ class AuditLogger:
         resource: str,
         action: str,
         success: bool,
-        required_permissions: Optional[list] = None,
-        user_permissions: Optional[list] = None,
-        error_message: Optional[str] = None,
+        required_permissions: list | None = None,
+        user_permissions: list | None = None,
+        error_message: str | None = None,
     ) -> None:
         """
         Log an authorization check.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
-import pytest
-import tempfile
-import shutil
 import asyncio
-from pathlib import Path
+import shutil
+import tempfile
 
-from rule_manager.storage.yaml_store import YAMLRuleStore
-from rule_manager.models.base import Rule, RuleSet, RuleScope, RuleAction, RuleContext
+import pytest
+
 from rule_manager.core.engine import RuleEngine
+from rule_manager.models.base import Rule, RuleAction, RuleContext, RuleScope, RuleSet
+from rule_manager.storage.yaml_store import YAMLRuleStore
 
 
 @pytest.fixture

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,16 +1,17 @@
-import pytest
 from datetime import datetime
+
+import pytest
 from pydantic import ValidationError
 
 from rule_manager.models.base import (
+    PriorityTieBreaking,
     Rule,
-    RuleSet,
-    RuleScope,
     RuleAction,
     RuleContext,
     RuleEvaluationResult,
     RuleEvaluationSummary,
-    PriorityTieBreaking,
+    RuleScope,
+    RuleSet,
 )
 
 

--- a/tests/unit/test_yaml_store.py
+++ b/tests/unit/test_yaml_store.py
@@ -1,11 +1,12 @@
-import pytest
-import tempfile
 import shutil
+import tempfile
 from pathlib import Path
 
+import pytest
+
+from rule_manager.models.base import Rule, RuleAction, RuleScope, RuleSet
+from rule_manager.models.errors import RuleNotFoundError, UnexpectedError
 from rule_manager.storage.yaml_store import YAMLRuleStore
-from rule_manager.models.base import Rule, RuleSet, RuleScope, RuleAction
-from rule_manager.models.errors import RuleNotFoundError
 
 
 class TestYAMLRuleStore:
@@ -102,7 +103,7 @@ class TestYAMLRuleStore:
         await self.store.add_rule(rule)
 
         # Add same rule again - should fail
-        with pytest.raises(Exception):  # Should raise an error for duplicate
+        with pytest.raises(UnexpectedError):
             await self.store.add_rule(rule)
 
     async def test_update_rule(self):


### PR DESCRIPTION
## Summary
- reorder imports and drop unused imports
- adjust exception chaining for DSL and YAML store modules
- add file-level Ruff directives for scripts
- use built-in collection types
- tweak tests for stricter error checking

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'semver')*

------
https://chatgpt.com/codex/tasks/task_e_685d3ff480c4832c803abc1f130b28f1